### PR TITLE
chore: return mime_type and data instead of text/file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ use wayland_clipboard_listener::WlListenType;
 fn main() {
     let mut stream = WlClipboardPasteStream::init(WlListenType::ListenOnCopy).unwrap();
     for context in stream.paste_stream().flatten().flatten() {
+    //  Note: MIME type priority is ignored when WlListenType is ListenOnSelect
+    //  stream.set_priority(vec![
+    //      "image/jpeg".into(),
+    //      "text/plain;charset=utf-8".into(),
+    //  ]);
         println!("{context:?}");
     }
 }

--- a/marine-clipboard-tools/src/bin/marine_paste.rs
+++ b/marine-clipboard-tools/src/bin/marine_paste.rs
@@ -10,10 +10,7 @@ fn main() -> Result<(), WlClipboardListenerError> {
         eprintln!("Warning, no context in clipboard");
         return Ok(());
     };
-    let context = match context {
-        wayland_clipboard_listener::ClipBoardListenContext::Text(text) => text.as_bytes().to_vec(),
-        wayland_clipboard_listener::ClipBoardListenContext::File(bites) => bites,
-    };
+    let context = context.context;
     stdout().write_all(&context).unwrap();
     Ok(())
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -101,6 +101,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
                 }
                 if let WlListenType::ListenOnSelect = state.listentype {
                     let (read, write) = pipe().unwrap();
+                    state.current_type = Some(TEXT.to_string());
                     id.receive(TEXT.to_string(), write.as_fd());
                     drop(write);
                     state.pipereader = Some(read);
@@ -149,6 +150,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
                     } else {
                         select_mimetype(state)
                     };
+                    state.current_type = Some(mimetype.clone());
                     let (read, write) = pipe().unwrap();
                     offer.receive(mimetype, write.as_fd());
                     drop(write);


### PR DESCRIPTION
Everything works as expected. When in ListenOnSelect, if the user copies an image or any file that doesn't involve text/plain;charset=utf-8, it returns an empty Vec with the type text/plain;charset=utf-8 instead of None. 