### PR TITLE
Fix/clipboard selection race

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -198,7 +198,7 @@ impl Dispatch<ext_data_control_source_v1::ExtDataControlSourceV1, ()>
 impl Dispatch<ext_data_control_offer_v1::ExtDataControlOfferV1, ()> for WlClipboardListenerStream {
     fn event(
         state: &mut Self,
-        _proxy: &ext_data_control_offer_v1::ExtDataControlOfferV1,
+        proxy: &ext_data_control_offer_v1::ExtDataControlOfferV1,
         event: <ext_data_control_offer_v1::ExtDataControlOfferV1 as Proxy>::Event,
         _data: &(),
         _conn: &Connection,
@@ -207,7 +207,7 @@ impl Dispatch<ext_data_control_offer_v1::ExtDataControlOfferV1, ()> for WlClipbo
         if let ext_data_control_offer_v1::Event::Offer { mime_type } = event {
             state
                 .offer_mime_types
-                .entry(_proxy.id().protocol_id())
+                .entry(proxy.id().protocol_id())
                 .or_default()
                 .push(mime_type);
         }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -96,10 +96,14 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()>
     ) {
         match event {
             ext_data_control_device_v1::Event::DataOffer { id } => {
-                if state.copy_data.is_some() {
-                    return;
-                }
+                state
+                    .offer_mime_types
+                    .entry(id.id().protocol_id())
+                    .or_default();
                 if let WlListenType::ListenOnSelect = state.listentype {
+                    if state.copy_data.is_some() {
+                        return;
+                    }
                     let (read, write) = pipe().unwrap();
                     state.current_type = Some(TEXT.to_string());
                     id.receive(TEXT.to_string(), write.as_fd());
@@ -108,30 +112,24 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()>
                 }
             }
             ext_data_control_device_v1::Event::Finished => {
-                let source = state
-                    .data_manager
-                    .as_ref()
-                    .unwrap()
-                    .create_data_source(qh, ());
-                state
-                    .data_device
-                    .as_ref()
-                    .unwrap()
-                    .set_selection(Some(&source));
+                state.clear_offers();
+                if let Some(device) = state.data_device.take() {
+                    device.destroy();
+                }
+                state.set_data_device(qh);
             }
             ext_data_control_device_v1::Event::PrimarySelection { id } => {
-                if let Some(offer) = id {
-                    offer.destroy();
-                }
+                state.replace_primary_selection_offer(id);
             }
             ext_data_control_device_v1::Event::Selection { id } => {
-                let Some(offer) = id else {
-                    return;
-                };
+                state.replace_selection_offer(id.clone());
                 // if is copying, not run this
                 if state.copy_data.is_some() {
                     return;
                 }
+                let Some(offer) = id else {
+                    return;
+                };
                 // TODO: how can I handle the mimetype?
                 let select_mimetype = |state: &WlClipboardListenerStream| {
                     if state.is_text() || state.mime_types.is_empty() {
@@ -207,7 +205,11 @@ impl Dispatch<ext_data_control_offer_v1::ExtDataControlOfferV1, ()> for WlClipbo
         _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
         if let ext_data_control_offer_v1::Event::Offer { mime_type } = event {
-            state.mime_types.push(mime_type);
+            state
+                .offer_mime_types
+                .entry(_proxy.id().protocol_id())
+                .or_default()
+                .push(mime_type);
         }
     }
 }

--- a/src/dispatch_wlr.rs
+++ b/src/dispatch_wlr.rs
@@ -200,7 +200,7 @@ impl Dispatch<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1, ()>
 {
     fn event(
         state: &mut Self,
-        _proxy: &zwlr_data_control_offer_v1::ZwlrDataControlOfferV1,
+        proxy: &zwlr_data_control_offer_v1::ZwlrDataControlOfferV1,
         event: <zwlr_data_control_offer_v1::ZwlrDataControlOfferV1 as Proxy>::Event,
         _data: &(),
         _conn: &Connection,
@@ -209,7 +209,7 @@ impl Dispatch<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1, ()>
         if let zwlr_data_control_offer_v1::Event::Offer { mime_type } = event {
             state
                 .offer_mime_types
-                .entry(_proxy.id().protocol_id())
+                .entry(proxy.id().protocol_id())
                 .or_default()
                 .push(mime_type);
         }

--- a/src/dispatch_wlr.rs
+++ b/src/dispatch_wlr.rs
@@ -96,10 +96,14 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
     ) {
         match event {
             zwlr_data_control_device_v1::Event::DataOffer { id } => {
-                if state.copy_data.is_some() {
-                    return;
-                }
+                state
+                    .offer_mime_types
+                    .entry(id.id().protocol_id())
+                    .or_default();
                 if let WlListenType::ListenOnSelect = state.listentype {
+                    if state.copy_data.is_some() {
+                        return;
+                    }
                     let (read, write) = pipe().unwrap();
                     state.current_type = Some(TEXT.to_string());
                     id.receive(TEXT.to_string(), write.as_fd());
@@ -108,30 +112,24 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
                 }
             }
             zwlr_data_control_device_v1::Event::Finished => {
-                let source = state
-                    .data_manager
-                    .as_ref()
-                    .unwrap()
-                    .create_data_source(qh, ());
-                state
-                    .data_device
-                    .as_ref()
-                    .unwrap()
-                    .set_selection(Some(&source));
+                state.clear_offers();
+                if let Some(device) = state.data_device.take() {
+                    device.destroy();
+                }
+                state.set_data_device(qh);
             }
             zwlr_data_control_device_v1::Event::PrimarySelection { id } => {
-                if let Some(offer) = id {
-                    offer.destroy();
-                }
+                state.replace_primary_selection_offer(id);
             }
             zwlr_data_control_device_v1::Event::Selection { id } => {
-                let Some(offer) = id else {
-                    return;
-                };
+                state.replace_selection_offer(id.clone());
                 // if is copying, not run this
                 if state.copy_data.is_some() {
                     return;
                 }
+                let Some(offer) = id else {
+                    return;
+                };
                 // TODO: how can I handle the mimetype?
                 let select_mimetype = |state: &WlClipboardListenerStreamWlr| {
                     if state.is_text() || state.mime_types.is_empty() {
@@ -209,7 +207,11 @@ impl Dispatch<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1, ()>
         _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
         if let zwlr_data_control_offer_v1::Event::Offer { mime_type } = event {
-            state.mime_types.push(mime_type);
+            state
+                .offer_mime_types
+                .entry(_proxy.id().protocol_id())
+                .or_default()
+                .push(mime_type);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,8 +399,12 @@ impl WlClipboardListenerStream {
             queue.blocking_dispatch(self)?;
         }
 
-        // roundtrip to init pipereader
-        queue.roundtrip(self)?;
+        // Flush the receive request so the source can start writing, but avoid
+        // a full roundtrip which can race in a newer selection and replace the
+        // pipe reader we are about to consume.
+        queue
+            .flush()
+            .map_err(|e| WlClipboardListenerError::QueueError(e.to_string()))?;
         let mut read = self.pipereader.as_ref().unwrap();
         let mut context = vec![];
         read.read_to_end(&mut context)
@@ -427,8 +431,9 @@ impl WlClipboardListenerStream {
             .map_err(|e| WlClipboardListenerError::QueueError(e.to_string()))?;
         queue.blocking_dispatch(self)?;
         if self.pipereader.is_some() {
-            // roundtrip to init pipereader
-            queue.roundtrip(self)?;
+            queue
+                .flush()
+                .map_err(|e| WlClipboardListenerError::QueueError(e.to_string()))?;
             let mut read = self.pipereader.as_ref().unwrap();
             let mut context = vec![];
             read.read_to_end(&mut context)
@@ -688,8 +693,12 @@ impl WlClipboardListenerStreamWlr {
             queue.blocking_dispatch(self)?;
         }
 
-        // roundtrip to init pipereader
-        queue.roundtrip(self)?;
+        // Flush the receive request so the source can start writing, but avoid
+        // a full roundtrip which can race in a newer selection and replace the
+        // pipe reader we are about to consume.
+        queue
+            .flush()
+            .map_err(|e| WlClipboardListenerError::QueueError(e.to_string()))?;
         let mut read = self.pipereader.as_ref().unwrap();
         let mut context = vec![];
         read.read_to_end(&mut context)
@@ -716,8 +725,9 @@ impl WlClipboardListenerStreamWlr {
             .map_err(|e| WlClipboardListenerError::QueueError(e.to_string()))?;
         queue.blocking_dispatch(self)?;
         if self.pipereader.is_some() {
-            // roundtrip to init pipereader
-            queue.roundtrip(self)?;
+            queue
+                .flush()
+                .map_err(|e| WlClipboardListenerError::QueueError(e.to_string()))?;
             let mut read = self.pipereader.as_ref().unwrap();
             let mut context = vec![];
             read.read_to_end(&mut context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,17 +120,18 @@ mod dispatch;
 #[cfg(feature = "wlr-data-control")]
 mod dispatch_wlr;
 
+use std::collections::HashMap;
 use std::io::Read;
 
-use wayland_client::{protocol::wl_seat, Connection, DispatchError, EventQueue};
+use wayland_client::{protocol::wl_seat, Connection, DispatchError, EventQueue, Proxy};
 
 use wayland_protocols::ext::data_control::v1::client::{
-    ext_data_control_device_v1, ext_data_control_manager_v1,
+    ext_data_control_device_v1, ext_data_control_manager_v1, ext_data_control_offer_v1,
 };
 
 #[cfg(feature = "wlr-data-control")]
 use wayland_protocols_wlr::data_control::v1::client::{
-    zwlr_data_control_device_v1, zwlr_data_control_manager_v1,
+    zwlr_data_control_device_v1, zwlr_data_control_manager_v1, zwlr_data_control_offer_v1,
 };
 
 use std::sync::{Arc, Mutex};
@@ -278,7 +279,10 @@ pub struct WlClipboardListenerStream {
     seat_name: Option<String>,
     data_manager: Option<ext_data_control_manager_v1::ExtDataControlManagerV1>,
     data_device: Option<ext_data_control_device_v1::ExtDataControlDeviceV1>,
+    offer_mime_types: HashMap<u32, Vec<String>>,
     mime_types: Vec<String>,
+    selection_offer: Option<ext_data_control_offer_v1::ExtDataControlOfferV1>,
+    primary_selection_offer: Option<ext_data_control_offer_v1::ExtDataControlOfferV1>,
     set_priority: Option<Vec<String>>,
     pipereader: Option<os_pipe::PipeReader>,
     current_type: Option<String>,
@@ -319,7 +323,10 @@ impl WlClipboardListenerStream {
             seat_name: None,
             data_manager: None,
             data_device: None,
+            offer_mime_types: HashMap::new(),
             mime_types: Vec::new(),
+            selection_offer: None,
+            primary_selection_offer: None,
             set_priority: None,
             pipereader: None,
             current_type: None,
@@ -467,6 +474,47 @@ impl WlClipboardListenerStream {
         !self.mime_types.is_empty()
             && self.mime_types.contains(&TEXT.to_string())
             && !self.mime_types.contains(&IMAGE.to_string())
+    }
+
+    fn replace_selection_offer(
+        &mut self,
+        offer: Option<ext_data_control_offer_v1::ExtDataControlOfferV1>,
+    ) {
+        if let Some(old_offer) = self.selection_offer.take() {
+            self.offer_mime_types.remove(&old_offer.id().protocol_id());
+            old_offer.destroy();
+        }
+
+        self.mime_types = offer
+            .as_ref()
+            .and_then(|offer| self.offer_mime_types.remove(&offer.id().protocol_id()))
+            .unwrap_or_default();
+
+        self.selection_offer = offer;
+    }
+
+    fn replace_primary_selection_offer(
+        &mut self,
+        offer: Option<ext_data_control_offer_v1::ExtDataControlOfferV1>,
+    ) {
+        if let Some(old_offer) = self.primary_selection_offer.take() {
+            self.offer_mime_types.remove(&old_offer.id().protocol_id());
+            old_offer.destroy();
+        }
+
+        self.primary_selection_offer = offer;
+    }
+
+    fn clear_offers(&mut self) {
+        if let Some(offer) = self.selection_offer.take() {
+            offer.destroy();
+        }
+        if let Some(offer) = self.primary_selection_offer.take() {
+            offer.destroy();
+        }
+
+        self.offer_mime_types.clear();
+        self.mime_types.clear();
     }
 }
 
@@ -570,7 +618,10 @@ pub struct WlClipboardListenerStreamWlr {
     seat_name: Option<String>,
     data_manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
     data_device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
+    offer_mime_types: HashMap<u32, Vec<String>>,
     mime_types: Vec<String>,
+    selection_offer: Option<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1>,
+    primary_selection_offer: Option<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1>,
     set_priority: Option<Vec<String>>,
     pipereader: Option<os_pipe::PipeReader>,
     current_type: Option<String>,
@@ -613,7 +664,10 @@ impl WlClipboardListenerStreamWlr {
             seat_name: None,
             data_manager: None,
             data_device: None,
+            offer_mime_types: HashMap::new(),
             mime_types: Vec::new(),
+            selection_offer: None,
+            primary_selection_offer: None,
             set_priority: None,
             pipereader: None,
             current_type: None,
@@ -761,5 +815,46 @@ impl WlClipboardListenerStreamWlr {
         !self.mime_types.is_empty()
             && self.mime_types.contains(&TEXT.to_string())
             && !self.mime_types.contains(&IMAGE.to_string())
+    }
+
+    fn replace_selection_offer(
+        &mut self,
+        offer: Option<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1>,
+    ) {
+        if let Some(old_offer) = self.selection_offer.take() {
+            self.offer_mime_types.remove(&old_offer.id().protocol_id());
+            old_offer.destroy();
+        }
+
+        self.mime_types = offer
+            .as_ref()
+            .and_then(|offer| self.offer_mime_types.remove(&offer.id().protocol_id()))
+            .unwrap_or_default();
+
+        self.selection_offer = offer;
+    }
+
+    fn replace_primary_selection_offer(
+        &mut self,
+        offer: Option<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1>,
+    ) {
+        if let Some(old_offer) = self.primary_selection_offer.take() {
+            self.offer_mime_types.remove(&old_offer.id().protocol_id());
+            old_offer.destroy();
+        }
+
+        self.primary_selection_offer = offer;
+    }
+
+    fn clear_offers(&mut self) {
+        if let Some(offer) = self.selection_offer.take() {
+            offer.destroy();
+        }
+        if let Some(offer) = self.primary_selection_offer.take() {
+            offer.destroy();
+        }
+
+        self.offer_mime_types.clear();
+        self.mime_types.clear();
     }
 }


### PR DESCRIPTION
Hi there, me again.

## Summary

This fixes a clipboard watcher stall after many rapid clipboard updates.

The branch is split into 2 commits:

1. `fix: avoid selection read race in watch path`
2. `fix: track offer state across selection lifecycle`

## Root Cause

There were 2 problems in the long-lived watcher path.

First, after `receive()`, the code used `roundtrip()` before reading from the pipe. In a persistent watcher, that can process a newer `Selection` before the old pipe is consumed, replacing the in-flight read state. The first commit changes this to `flush()`.

Second, MIME types and offer/device state were not tracked per offer strongly enough. The second commit:
- tracks MIME types per offer
- replaces old `Selection` / `PrimarySelection` offers cleanly
- destroys and recreates the data device on `Finished`

Applied to both `ext-data-control` and `wlr-data-control`, because both paths have the same watcher structure.

## Repro

A long-lived watcher can stop receiving new clipboard contents after many rapid clipboard updates, for example repeated `wl-copy` in the same session.

I hit this in `bubcop`: https://github.com/Magniquick/bubcop

Granted, this is a bit of an edge-case scenario, but I think it is better to fix it here than debug it later in downstream apps.

## Verification

Checked with:
- `cargo test`
- `cargo test --features wlr-data-control`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features wlr-data-control -- -D warnings`

Also tested locally with repeated rapid `wl-copy` updates in one watcher session.