### PR TITLE
replace log with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,7 @@ version = "0.2.4"
 dependencies = [
  "libc",
  "nix",
+ "tracing-subscriber",
  "wayland-clipboard-listener",
 ]
 
@@ -91,6 +98,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "os_pipe"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +121,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -147,6 +175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,10 +227,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wayland-backend"
@@ -224,9 +333,10 @@ dependencies = [
 name = "wayland-clipboard-listener"
 version = "0.6.1"
 dependencies = [
- "log",
  "os_pipe",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ wayland-protocols-wlr = { version = "0.3.8", default-features = false, features 
 ], optional = true }
 os_pipe = "1.2.2"
 thiserror = "2.0.12"
-log = "0.4.27"
+tracing = { version = "0.1", features = ["attributes"] }
+tracing-subscriber = "0.3"
 
 [features]
 wlr-data-control = ["wayland-protocols-wlr"]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,6 +2,7 @@ use wayland_clipboard_listener::WlClipboardPasteStream;
 use wayland_clipboard_listener::WlListenType;
 
 fn main() {
+    tracing_subscriber::fmt::init();
     let mut stream = WlClipboardPasteStream::init(WlListenType::ListenOnCopy).unwrap();
 
     for context in stream.paste_stream().flatten() {

--- a/marine-clipboard-tools/Cargo.toml
+++ b/marine-clipboard-tools/Cargo.toml
@@ -12,3 +12,4 @@ keywords = ["wayland"]
 wayland-clipboard-listener.workspace = true
 nix = { version = "0.31.2", features = ["fs", "process"] }
 libc = "0.2.172"
+tracing-subscriber = "0.3"

--- a/marine-clipboard-tools/src/bin/maine_clipboard_watcher.rs
+++ b/marine-clipboard-tools/src/bin/maine_clipboard_watcher.rs
@@ -2,6 +2,7 @@ use wayland_clipboard_listener::WlClipboardPasteStream;
 use wayland_clipboard_listener::WlListenType;
 
 fn main() {
+    tracing_subscriber::fmt::init();
     let mut stream = WlClipboardPasteStream::init(WlListenType::ListenOnCopy).unwrap();
     for context in stream.paste_stream().flatten() {
         println!("{context:?}");

--- a/marine-clipboard-tools/src/bin/marine_copy.rs
+++ b/marine-clipboard-tools/src/bin/marine_copy.rs
@@ -7,6 +7,7 @@ use wayland_clipboard_listener::{WlClipboardCopyStream, WlClipboardListenerError
 use std::io::{stdin, Read};
 
 fn main() -> Result<(), WlClipboardListenerError> {
+    tracing_subscriber::fmt::init();
     let args = std::env::args();
     let context = {
         let len = args.len();

--- a/marine-clipboard-tools/src/bin/marine_paste.rs
+++ b/marine-clipboard-tools/src/bin/marine_paste.rs
@@ -5,6 +5,7 @@ use wayland_clipboard_listener::{
 };
 
 fn main() -> Result<(), WlClipboardListenerError> {
+    tracing_subscriber::fmt::init();
     let mut stream = WlClipboardPasteStream::init(WlListenType::ListenOnCopy)?;
     let Some(ClipBoardListenMessage { context, .. }) = stream.try_get_clipboard()? else {
         eprintln!("Warning, no context in clipboard");

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,4 +1,5 @@
 use super::WlClipboardListenerStream;
+use tracing::{info, instrument};
 
 use std::fs::File;
 use std::io::Write;
@@ -22,6 +23,7 @@ use crate::{
 };
 
 impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListenerStream {
+    #[instrument(skip(state, registry, _data, _conn, qh))]
     fn event(
         state: &mut Self,
         registry: &wl_registry::WlRegistry,
@@ -55,6 +57,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListenerStream {
 }
 
 impl Dispatch<wl_seat::WlSeat, ()> for WlClipboardListenerStream {
+    #[instrument(skip(state, _proxy, _data, _conn, _qhandle))]
     fn event(
         state: &mut Self,
         _proxy: &wl_seat::WlSeat,
@@ -72,6 +75,7 @@ impl Dispatch<wl_seat::WlSeat, ()> for WlClipboardListenerStream {
 impl Dispatch<ext_data_control_manager_v1::ExtDataControlManagerV1, ()>
     for WlClipboardListenerStream
 {
+    #[instrument(skip(_state, _proxy, _event, _data, _conn, _qhandle))]
     fn event(
         _state: &mut Self,
         _proxy: &ext_data_control_manager_v1::ExtDataControlManagerV1,
@@ -86,6 +90,7 @@ impl Dispatch<ext_data_control_manager_v1::ExtDataControlManagerV1, ()>
 impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()>
     for WlClipboardListenerStream
 {
+    #[instrument(skip(state, _proxy, _data, _conn, qh))]
     fn event(
         state: &mut Self,
         _proxy: &ext_data_control_device_v1::ExtDataControlDeviceV1,
@@ -156,7 +161,7 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()>
                 }
             }
             _ => {
-                log::info!("unhandled event: {event:?}");
+                info!("unhandled event: {event:?}");
             }
         }
     }
@@ -168,6 +173,7 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()>
 impl Dispatch<ext_data_control_source_v1::ExtDataControlSourceV1, ()>
     for WlClipboardListenerStream
 {
+    #[instrument(skip(state, _proxy, _data, _conn, _qhandle))]
     fn event(
         state: &mut Self,
         _proxy: &ext_data_control_source_v1::ExtDataControlSourceV1,
@@ -196,6 +202,7 @@ impl Dispatch<ext_data_control_source_v1::ExtDataControlSourceV1, ()>
 }
 
 impl Dispatch<ext_data_control_offer_v1::ExtDataControlOfferV1, ()> for WlClipboardListenerStream {
+    #[instrument(skip(state, proxy, _data, _conn, _qhandle))]
     fn event(
         state: &mut Self,
         proxy: &ext_data_control_offer_v1::ExtDataControlOfferV1,

--- a/src/dispatch_wlr.rs
+++ b/src/dispatch_wlr.rs
@@ -1,4 +1,5 @@
 use super::WlClipboardListenerStreamWlr;
+use tracing::{info, instrument};
 
 use std::fs::File;
 use std::io::Write;
@@ -22,6 +23,7 @@ use crate::{
 };
 
 impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListenerStreamWlr {
+    #[instrument(skip(state, registry, _data, _conn, qh))]
     fn event(
         state: &mut Self,
         registry: &wl_registry::WlRegistry,
@@ -55,6 +57,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListenerStreamWlr {
 }
 
 impl Dispatch<wl_seat::WlSeat, ()> for WlClipboardListenerStreamWlr {
+    #[instrument(skip(state, _proxy, _data, _conn, _qhandle))]
     fn event(
         state: &mut Self,
         _proxy: &wl_seat::WlSeat,
@@ -72,6 +75,7 @@ impl Dispatch<wl_seat::WlSeat, ()> for WlClipboardListenerStreamWlr {
 impl Dispatch<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, ()>
     for WlClipboardListenerStreamWlr
 {
+    #[instrument(skip(_state, _proxy, _event, _data, _conn, _qhandle))]
     fn event(
         _state: &mut Self,
         _proxy: &zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
@@ -86,6 +90,7 @@ impl Dispatch<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, ()>
 impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
     for WlClipboardListenerStreamWlr
 {
+    #[instrument(skip(state, _proxy, _data, _conn, qh))]
     fn event(
         state: &mut Self,
         _proxy: &zwlr_data_control_device_v1::ZwlrDataControlDeviceV1,
@@ -156,7 +161,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
                 }
             }
             _ => {
-                log::info!("unhandled event: {event:?}");
+                info!("unhandled event: {event:?}");
             }
         }
     }
@@ -168,6 +173,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()>
 impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()>
     for WlClipboardListenerStreamWlr
 {
+    #[instrument(skip(state, _proxy, _data, _conn, _qhandle))]
     fn event(
         state: &mut Self,
         _proxy: &zwlr_data_control_source_v1::ZwlrDataControlSourceV1,
@@ -198,6 +204,7 @@ impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()>
 impl Dispatch<zwlr_data_control_offer_v1::ZwlrDataControlOfferV1, ()>
     for WlClipboardListenerStreamWlr
 {
+    #[instrument(skip(state, proxy, _data, _conn, _qhandle))]
     fn event(
         state: &mut Self,
         proxy: &zwlr_data_control_offer_v1::ZwlrDataControlOfferV1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ mod dispatch_wlr;
 
 use std::collections::HashMap;
 use std::io::Read;
+use tracing::instrument;
 
 use wayland_client::{protocol::wl_seat, Connection, DispatchError, EventQueue, Proxy};
 
@@ -194,6 +195,7 @@ impl WlClipboardPasteStream {
     /// init a paste steam, you can use WlListenType::ListenOnSelect to watch the select event
     /// It can just listen on text
     /// use ListenOnCopy will receive the mimetype, can copy many types
+    #[instrument]
     pub fn init(listentype: WlListenType) -> Result<Self, WlClipboardListenerError> {
         Ok(Self {
             inner: WlClipboardListenerStream::init(listentype)?,
@@ -306,6 +308,7 @@ impl Iterator for WlClipboardListenerStream {
 impl WlClipboardListenerStream {
     /// private init
     /// to init a stream
+    #[instrument]
     fn init(listentype: WlListenType) -> Result<Self, WlClipboardListenerError> {
         let conn = Connection::connect_to_env().map_err(|_| {
             WlClipboardListenerError::InitFailed("Cannot connect to wayland".to_string())
@@ -360,6 +363,7 @@ impl WlClipboardListenerStream {
     /// pass [Vec<u8>] as data
     /// now it can just copy text
     /// It will always live in the background, so you need to handle it yourself
+    #[instrument(skip(self, data))]
     fn copy_to_clipboard(
         &mut self,
         data: Vec<u8>,
@@ -396,6 +400,7 @@ impl WlClipboardListenerStream {
 
     /// get data from clipboard for once
     /// it is also used in iter
+    #[instrument(skip(self))]
     fn get_clipboard_sync(&mut self) -> Result<ClipBoardListenMessage, WlClipboardListenerError> {
         // get queue, start blocking_dispatch for first loop
         let queue = self.queue.clone().unwrap();
@@ -428,6 +433,7 @@ impl WlClipboardListenerStream {
 
     /// get data from clipboard for once
     /// it is also used in iter
+    #[instrument(skip(self))]
     fn try_get_clipboard(
         &mut self,
     ) -> Result<Option<ClipBoardListenMessage>, WlClipboardListenerError> {
@@ -529,6 +535,7 @@ impl WlClipboardPasteStreamWlr {
     /// init a paste steam, you can use WlListenType::ListenOnSelect to watch the select event
     /// It can just listen on text
     /// use ListenOnCopy will receive the mimetype, can copy many types
+    #[instrument]
     pub fn init(listentype: WlListenType) -> Result<Self, WlClipboardListenerError> {
         Ok(Self {
             inner: WlClipboardListenerStreamWlr::init(listentype)?,
@@ -647,6 +654,7 @@ impl Iterator for WlClipboardListenerStreamWlr {
 impl WlClipboardListenerStreamWlr {
     /// private init
     /// to init a stream
+    #[instrument]
     fn init(listentype: WlListenType) -> Result<Self, WlClipboardListenerError> {
         let conn = Connection::connect_to_env().map_err(|_| {
             WlClipboardListenerError::InitFailed("Cannot connect to wayland".to_string())
@@ -701,6 +709,7 @@ impl WlClipboardListenerStreamWlr {
     /// pass [Vec<u8>] as data
     /// now it can just copy text
     /// It will always live in the background, so you need to handle it yourself
+    #[instrument(skip(self, data))]
     fn copy_to_clipboard(
         &mut self,
         data: Vec<u8>,
@@ -737,6 +746,7 @@ impl WlClipboardListenerStreamWlr {
 
     /// get data from clipboard for once
     /// it is also used in iter
+    #[instrument(skip(self))]
     fn get_clipboard_sync(&mut self) -> Result<ClipBoardListenMessage, WlClipboardListenerError> {
         // get queue, start blocking_dispatch for first loop
         let queue = self.queue.clone().unwrap();
@@ -769,6 +779,7 @@ impl WlClipboardListenerStreamWlr {
 
     /// get data from clipboard for once
     /// it is also used in iter
+    #[instrument(skip(self))]
     fn try_get_clipboard(
         &mut self,
     ) -> Result<Option<ClipBoardListenMessage>, WlClipboardListenerError> {


### PR DESCRIPTION
 #14 this PR replaces the old `log` based logging with `tracing`. I added `tracing` and `tracing-subscriber`, updated the logging setup, and added some basic tracing messages around clipboard/event handling to make debugging easier and improve visibility into the Wayland event flow.
